### PR TITLE
Use only the typename, StructureType is added automatically

### DIFF
--- a/fastjet/plugins/SISCone/SISConeBasePlugin.cc
+++ b/fastjet/plugins/SISCone/SISConeBasePlugin.cc
@@ -9,8 +9,8 @@ FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 // By default this does a simple direct comparison but it can be
 // overloaded for higher precision [recommended if possible]
 bool SISConeBasePlugin::UserScaleBase::is_larger(const PseudoJet & a, const PseudoJet & b) const{
-  return a.structure_of<UserScaleBase::StructureType>().ordering_var2()
-       > b.structure_of<UserScaleBase::StructureType>().ordering_var2();
+  return a.structure_of<UserScaleBase>().ordering_var2()
+       > b.structure_of<UserScaleBase>().ordering_var2();
 }
 
 FASTJET_END_NAMESPACE


### PR DESCRIPTION
This change fixes the compilation on MacOS with Xcode 9.3.