### PR TITLE
Sort input file list

### DIFF
--- a/fjcontrib/configure
+++ b/fjcontrib/configure
@@ -10,8 +10,8 @@
 #------------------------------------------------------------------------
 # the list of contribs supported by this script
 #------------------------------------------------------------------------
-all_contribs=`find . -mindepth 2 -maxdepth 2 -name VERSION -not -print \
-                 | sed 's/\.\///g;s/\/.*$//g' | grep -v "Template"`
+all_contribs=`find . -mindepth 2 -maxdepth 2 -name VERSION -not -print |
+                 sed 's/\.\///g;s/\/.*$//g' | grep -v "Template"`
 
 #------------------------------------------------------------------------
 # default values prior to the arg parsing

--- a/fjcontrib/configure
+++ b/fjcontrib/configure
@@ -11,6 +11,7 @@
 # the list of contribs supported by this script
 #------------------------------------------------------------------------
 all_contribs=`find . -mindepth 2 -maxdepth 2 -name VERSION -not -print |
+                 sort |
                  sed 's/\.\///g;s/\/.*$//g' | grep -v "Template"`
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
Sort input file list
so that `/usr/lib64/libfastjetcontribfragile.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.